### PR TITLE
Update to Logstash 2.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN JAVA_TRUSTSTORE=/usr/lib/jvm/java-1.7-openjdk/jre/lib/security/cacerts \
  && ln -s "$SYSTEM_TRUSTSTORE" "$JAVA_TRUSTSTORE"
 
 # Install logstash
-ENV LOGSTASH_VERSION 2.1.1
-ENV LOGSTASH_SHA1 d71a6e015509030ab6012adcf79291994ece0b39
+ENV LOGSTASH_VERSION 2.1.3
+ENV LOGSTASH_SHA1 283f6d8842df52c7d69f77b5c6d4755ee942b291
 
 RUN curl -O https://download.elastic.co/logstash/logstash/logstash-${LOGSTASH_VERSION}.tar.gz && \
     echo "${LOGSTASH_SHA1}  logstash-${LOGSTASH_VERSION}.tar.gz" | sha1sum -c - && \


### PR DESCRIPTION
This gives us
https://github.com/logstash-plugins/logstash-mixin-http_client/pull/18,
which solves
https://github.com/logstash-plugins/logstash-output-http/issues/20,
which ensures Logstash doesn't try to use dead connections to send its
traffic.

(Well, it still _tries_ to use them sometimes, but it retries the
requests when that happens)
