### PR TITLE
Check before reusing ES connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN curl -O https://download.elastic.co/logstash/logstash/logstash-${LOGSTASH_VE
     tar zxf "/logstash-${LOGSTASH_VERSION}.tar.gz" && \
     rm "/logstash-${LOGSTASH_VERSION}.tar.gz"
 
+# Blow away the existing elasticsearch plugin so we can instal our version instead.
+RUN rm -rf /logstash-2.1.3/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch-2.4.1-java
+
 # Install logstash plugins. We need --no-verify to install Aptible Gems.
 ADD Gemfile "/logstash-${LOGSTASH_VERSION}/Gemfile"
 RUN "/logstash-${LOGSTASH_VERSION}/bin/plugin" install --no-verify

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "flores", "~> 0.0.6", :group => :development
 
 gem "logstash-input-http"
 gem 'logstash-output-syslog', :git => 'https://github.com/aaw/logstash-output-syslog', :branch => 'aptible'
+gem 'logstash-output-elasticsearch', :git => 'https://github.com/krallin/logstash-output-elasticsearch', :ref => 'e6e3aa9'
 
 
 ######################################################################
@@ -80,7 +81,6 @@ gem "logstash-output-zeromq"
 gem "logstash-output-xmpp"
 gem "logstash-output-cloudwatch"
 gem "logstash-output-csv"
-gem "logstash-output-elasticsearch"
 gem "logstash-output-email"
 gem "logstash-output-exec"
 gem "logstash-output-file"


### PR DESCRIPTION
Pending confirmation by the affected customer, this should ensure that Logstash stops dropping connections to ES constantly (at least it does on my environment).

---

This essentially mirrors the fix that was implemented in the Logstash
HTTPS plugin but not ported to the Elasticsearch plugin. It exposes the
Manticore connection reuse configuration, and defaults it to 200ms.
