### PR TITLE
Do not quote destination in ADD statement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN curl -O https://download.elastic.co/logstash/logstash/logstash-${LOGSTASH_VE
 RUN rm -rf /logstash-2.1.3/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch-2.4.1-java
 
 # Install logstash plugins. We need --no-verify to install Aptible Gems.
-ADD Gemfile "/logstash-${LOGSTASH_VERSION}/Gemfile"
+ADD Gemfile /logstash-${LOGSTASH_VERSION}/Gemfile
 RUN "/logstash-${LOGSTASH_VERSION}/bin/plugin" install --no-verify
 
 # Add logstash run scripts and configuration


### PR DESCRIPTION
On Docker 1.5, this adds the file in `"/logstash-...` (i.e., the quotes
are interpreted as part of the path). On newer versions of Docker, the
quotes are actually expanded into a string.
