### PR TITLE
Move logstash-filter-drop to recommended gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,9 @@ gem "flores", "~> 0.0.6", :group => :development
 # Gems we recommend you keep around to use on Aptible #
 #######################################################
 
+gem "logstash-filter-drop"
 gem "logstash-input-http"
+
 gem 'logstash-output-syslog', :git => 'https://github.com/aaw/logstash-output-syslog', :branch => 'aptible'
 gem 'logstash-output-elasticsearch', :git => 'https://github.com/krallin/logstash-output-elasticsearch', :ref => 'e6e3aa9'
 
@@ -58,7 +60,6 @@ gem "logstash-filter-clone"
 gem "logstash-filter-csv"
 gem "logstash-filter-date"
 gem "logstash-filter-dns"
-gem "logstash-filter-drop"
 gem "logstash-filter-fingerprint"
 gem "logstash-filter-geoip"
 gem "logstash-filter-grok"


### PR DESCRIPTION
logstash-filter-drop is used in the default configuration to drop GET
requests (health checks). We need users to keep it around otherwise
Logstash won't boot.
